### PR TITLE
Fixed issue w/ package.json and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project was bootstrapped with [React Native](https://facebook.github.io/rea
 
 0. Clone this repo to your computer. (You'll need Xcode to be able to work on this)
 
-1. From the command line, run `react-native run ios` within this project.
+1. From the command line, run `react-native run-ios` within this project.
 
 2. Open a new tab in your terminal. Clone the [Best Buy API Playground](https://github.com/bestbuy/api-playground)
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -141,4 +141,4 @@
 import { AppRegistry } from 'react-native';
 import routes from './app/routes';
 
-AppRegistry.registerComponent('Simple', () => () => routes);
+AppRegistry.registerComponent('BestBuyNative', () => () => routes); //The registered name must match your original name in order for the simulator to run the program

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "axios": "^0.15.3",
     "react": "15.4.1",
     "react-native": "0.39.1",
-    "react-router": "^4.0.0-alpha.6"
+    "react-router": "^4.0.0-alpha.6",
+    "react-router-native": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "babel-jest": "17.0.2",


### PR DESCRIPTION
Basically it looks like when you installed your npm package you did something like:
`npm install react-router-native`

instead of 
`npm i -S react-router-native`

Fixed a typo in the readme and the app registry so it would run on simulator. Also checked out what you had going on with the best buy api. Let me know if you want me to take a look again later on.